### PR TITLE
지도 좌표 재설정시 setCenter 대신 panTo로 좌표 부드럽게 이동하도록 수정

### DIFF
--- a/dist/Map.js
+++ b/dist/Map.js
@@ -18,8 +18,11 @@ export class Map extends React.PureComponent {
         const { options } = this.props;
         const { map } = this.state;
         if (map) {
+            if (prevOptions.center == null) {
+                map.setCenter(options.center)
+            }
             if (!prevOptions.center.equals(options.center)) {
-                map.setCenter(options.center);
+                map.panTo(options.center);
             }
             if (prevOptions.mapTypeId !== options.mapTypeId) {
                 map.setMapTypeId(options.mapTypeId || daum.maps.MapTypeId.SKYVIEW);

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -39,8 +39,12 @@ export class Map extends React.PureComponent<MapProps, State> {
     const { options } = this.props
     const { map } = this.state
     if (map) {
+      if (prevOptions.center == null) {
+          map.setCenter(options.center)
+      } 
+      
       if (!prevOptions.center.equals(options.center)) {
-        map.setCenter(options.center)
+          map.panTo(options.center);
       }
 
       if (prevOptions.mapTypeId !== options.mapTypeId) {


### PR DESCRIPTION
지도 좌표 재설정시 `setCenter` 대신 `panTo`를 사용하도록 하여 화면이 부드럽게 이동하도록 개선하였습니다.